### PR TITLE
feature(workspace-quick-switcher): Add translation for workspace quick switch component

### DIFF
--- a/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -50,7 +50,8 @@ zen-settings-workspaces-hide-default-container-indicator =
     .label = Hide the default container indicator in the tab bar
 zen-settings-workspaces-allow-pinned-tabs-for-different-workspaces = 
     .label = Allow workspaces have their own pinned tabs
-
+zen-settings-workspaces-show-quick-switch =
+.label = Enable workspace quick switch component
 
 pane-zen-theme-title = Theme Settings
 


### PR DESCRIPTION
This PR adds translations for the workspace quick switch component setting, ensuring that users can easily toggle the component in their preferred language.

This is part of 3 PRs required for the workspace quick switcher feature:
https://github.com/zen-browser/desktop/pull/1533
https://github.com/zen-browser/components/pull/20