### PR TITLE
Feature: Clear All Tabs Button – Add "Release to Clear" Translation for New Tab Button

### DIFF
--- a/en-US/browser/browser/zen-vertical-tabs.ftl
+++ b/en-US/browser/browser/zen-vertical-tabs.ftl
@@ -8,3 +8,5 @@ sidebar-zen-sidepanel =
 sidebar-zen-expand =
   .label = Expand Sidebar
   
+tabs-toolbar-new-tab-clear-all =
+  .label = Release to clear


### PR DESCRIPTION
This update adds alternate text to the "New Tab" button in the tabs toolbar while middle mouse button is pressed. The text indicates that releasing the mouse button will clear all tabs.

Related to https://github.com/zen-browser/desktop/pull/1560