### PR TITLE
Feature: Force container tabs to a workspace where that container is set as default

### DIFF
--- a/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -131,6 +131,8 @@ pane-zen-marketplace-title = Zen Mods
 
 zen-settings-workspaces-display-as-icon-strip = 
     .label = Display workspaces as an icon strip
+zen-settings-workspaces-force-container-tabs-to-workspace =
+    .label = Switch to workspace where container is set as default when opening container tabs
 
 zen-theme-marketplace-link = Visit Store
 


### PR DESCRIPTION
This commit adds a new preference option to automatically switch to the workspace where a container is set as the default when opening container tabs. This provides a more streamlined experience for users who manage their browsing across different workspaces with containers.

Depends on:
https://github.com/zen-browser/components/pull/53
https://github.com/zen-browser/desktop/pull/2095