### PR TITLE
Add shortcut for copying current URL as markdown

### DIFF
--- a/en-US/browser/browser/preferences/zen-preferences.ftl
+++ b/en-US/browser/browser/preferences/zen-preferences.ftl
@@ -252,6 +252,7 @@ zen-text-action-redo-shortcut = Redo
 zen-text-action-cut-shortcut = Cut
 zen-text-action-copy-shortcut = Copy
 zen-text-action-copy-url-shortcut = Copy current URL
+zen-text-action-copy-url-markdown-shortcut = Copy current URL as Markdown
 zen-text-action-paste-shortcut = Paste
 zen-text-action-select-all-shortcut = Select All
 zen-text-action-delete-shortcut = Delete


### PR DESCRIPTION
I10n string for [copy URL as Markdown feature](https://github.com/zen-browser/desktop/pull/4801)

Depends on: https://github.com/zen-browser/desktop/pull/4801